### PR TITLE
Fix for managementApiSecret

### DIFF
--- a/aws/fargate.yml
+++ b/aws/fargate.yml
@@ -248,7 +248,7 @@ Resources:
               Value: !Sub 
                 - |
                   port: 60000
-                  PRISMA_MANAGEMENT_API_SECRET: ${ManagementApiSecret}
+                  managementApiSecret: ${ManagementApiSecret}
                   databases:
                     default:
                       connector: ${DbConnector}


### PR DESCRIPTION
@mavilein 
Looks like you made an innocent mistake when changing over to PRISMA_CONFIG. Nobody's had management API security enabled since July 3rd. We should probably get this fixed ASAP and let everyone know that they should update due to a security vulnerability.
https://github.com/prismagraphql/prisma-templates/commit/a57bb5bc3002857b810f2758acb9c7e2be26ad73#diff-9691877145a8fd75478f29e28252bd98R249